### PR TITLE
Fix danger alert styling

### DIFF
--- a/pages/authorization.mdx
+++ b/pages/authorization.mdx
@@ -2,7 +2,7 @@ import { Code, Tabs, Steps, Callout } from "nextra/components";
 
 ## Authorization
 
-<Callout type="danger">
+<Callout type="error">
     <strong>Important:</strong> API tokens are sensitive and must be kept secret. Do not share or expose your token in frontend code or public code repositories.
 </Callout>
 


### PR DESCRIPTION
Seems nextra use 'error' instead of the usual 'danger' for alert callout styling. Ref: https://nextra.site/docs/built-ins/callout#error