### PR TITLE
fix: Update docsRepositoryBase URL

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -36,7 +36,7 @@ const config: DocsThemeConfig = {
   chat: {
     link: 'https://discord.gg/tTUMWFd',
   },
-  docsRepositoryBase: 'https://github.com/SomeRandomApi/docs',
+  docsRepositoryBase: 'https://github.com/SomeRandomApi/docs/blob/master/',
   footer: {
     text: `©️ ${new Date().getUTCFullYear()} Some Random API`,
   },


### PR DESCRIPTION
Fixed a bug that caused clicking the “Edit this page” button to lead to a 404 URL.